### PR TITLE
fix: translate button and mobile whitespace

### DIFF
--- a/docs/css/header.css
+++ b/docs/css/header.css
@@ -37,6 +37,7 @@
     padding: 1rem 0 1rem 1rem;
     font-weight: 700;
     font-size: .93rem;
+    border: none;
 }
 
 /* from metro.net */

--- a/docs/css/site.css
+++ b/docs/css/site.css
@@ -50,6 +50,7 @@ html, body {
 .container-outer {
   height: 100%;
   min-height: 100%;
+  overflow-x: hidden;
 }
 
 .usa-footer, .usa-footer__secondary-section {

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -37,6 +37,7 @@
     padding: 1rem 0 1rem 1rem;
     font-weight: 700;
     font-size: .93rem;
+    border: none;
 }
 
 /* from metro.net */

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -50,6 +50,7 @@ html, body {
 .container-outer {
   height: 100%;
   min-height: 100%;
+  overflow-x: hidden;
 }
 
 .usa-footer, .usa-footer__secondary-section {


### PR DESCRIPTION
Just fixing a couple of display issues, namely:

1. removing browser default border on the translate on some browsers, namely:
Firefox: 
![image](https://user-images.githubusercontent.com/7969234/229305851-e04527ba-35f0-43f5-966a-1ab1e19d5be0.png)
Chrome:
![image](https://user-images.githubusercontent.com/7969234/229305884-7586a9a1-cada-401b-bc2f-21757f72485a.png)

2. Getting rid of the weird mobile horizontal overflow. Not sure which element is actually causing this, but overflow-x hidden fixes it.
![image](https://user-images.githubusercontent.com/7969234/229306007-1730337c-3078-48d3-83a4-a9eaad4d33f2.png)
